### PR TITLE
ignore .babelrc in project & dependencies

### DIFF
--- a/lib/transforms/babel.js
+++ b/lib/transforms/babel.js
@@ -24,6 +24,7 @@ module.exports = function (options, output) {
 			],
 			exclude: [],
 			query: {
+				babelrc: false, // ignore any .babelrc in project & dependencies
 				cacheDirectory: true,
 				plugins: [
 					require.resolve('babel-plugin-add-module-exports', true)


### PR DESCRIPTION
People have reported this error with `n-ui`:

```
webpack --config webpack.config.demo.js --bail
ModuleBuildError: Module build failed: ReferenceError: [BABEL] /home/ubuntu/n-ui/node_modules/proptypes/index.js: Using removed Babel 5 option: /home/ubuntu/n-ui/node_modules/proptypes/.babelrc.loose - Specify the `loose` option for the relevant plugin you are using or use a preset that sets the option.
    at Logger.error (/home/ubuntu/n-ui/node_modules/babel-core/lib/transformation/file/logger.js:41:11)
    at OptionManager.mergeOptions (/home/ubuntu/n-ui/node_modules/babel-core/lib/transformation/file/options/option-manager.js:233:20)
    at OptionManager.init (/home/ubuntu/n-ui/node_modules/babel-core/lib/transformation/file/options/option-manager.js:383:12)
    at File.initOptions (/home/ubuntu/n-ui/node_modules/babel-core/lib/transformation/file/index.js:223:65)
    at new File (/home/ubuntu/n-ui/node_modules/babel-core/lib/transformation/file/index.js:140:24)
    at Pipeline.transform (/home/ubuntu/n-ui/node_modules/babel-core/lib/transformation/pipeline.js:46:16)
    at transpile (/home/ubuntu/n-ui/node_modules/babel-loader/index.js:38:20)
    at /home/ubuntu/n-ui/node_modules/babel-loader/lib/fs-cache.js:145:18
    at ReadFileContext.callback (/home/ubuntu/n-ui/node_modules/babel-loader/lib/fs-cache.js:28:23)
    at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:324:13)
    at DependenciesBlock.onModuleBuildFailed (/home/ubuntu/n-ui/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:315:19)
    at nextLoader (/home/ubuntu/n-ui/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:270:31)
    at /home/ubuntu/n-ui/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:292:15
    at context.callback (/home/ubuntu/n-ui/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:148:14)
    at /home/ubuntu/n-ui/node_modules/babel-loader/index.js:126:25
    at /home/ubuntu/n-ui/node_modules/babel-loader/lib/fs-cache.js:147:16
    at ReadFileContext.callback (/home/ubuntu/n-ui/node_modules/babel-loader/lib/fs-cache.js:28:23)
    at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:324:13)
```

I've found a hidden gem, a way to get it to ignore `.babelrc` in dependencies:

http://madole.xyz/babel-loaders-hidden-feature-babelrc-false/

In local testing, this seems to have fixed the aforementioned error 🎉 