### PR TITLE
add Handlebars loader for client-side usage of Handlebars templates

### DIFF
--- a/lib/transforms/base-js.js
+++ b/lib/transforms/base-js.js
@@ -13,6 +13,10 @@ module.exports = function (options, output) {
 			{
 				test: /\.html$/,
 				loader: 'raw'
+			},
+			{
+				test: /\.hbs$/,
+				loader: 'hbs'
 			}
 		])
 		output.plugins.push(


### PR DESCRIPTION
if anyone wants to use a .html template client-side, then it will need to be renamed to .hbs then simply `require('../path/to/template.hbs')`

and if you're the first person to use it server-side too, then you'll need to update Express' templating configuration to search for files with .hbs extension