### PR TITLE
Using Handlebars with .html files client-side

### DIFF
--- a/lib/transforms/babel.js
+++ b/lib/transforms/babel.js
@@ -18,7 +18,8 @@ module.exports = function (options, output) {
 			loader: require.resolve('babel-loader'),
 			include: [
 				/bower_components/,
-				/\/helpers\//, // handlebars helpers
+				path.resolve('./node_modules/@financial-times/n-handlebars/src/helpers'),
+				path.resolve('./server/helpers'), // more handlebars helpers
 				path.resolve('./client'),
 				path.resolve('./config'),
 				path.resolve('./shared')

--- a/lib/transforms/babel.js
+++ b/lib/transforms/babel.js
@@ -18,6 +18,7 @@ module.exports = function (options, output) {
 			loader: require.resolve('babel-loader'),
 			include: [
 				/bower_components/,
+				/\/helpers\//, // handlebars helpers
 				path.resolve('./client'),
 				path.resolve('./config'),
 				path.resolve('./shared')

--- a/lib/transforms/base-js.js
+++ b/lib/transforms/base-js.js
@@ -2,7 +2,7 @@ const BowerWebpackPlugin = require('bower-webpack-plugin');
 const path = require('path');
 
 const handlebarsConfig = {
-	debug: true,
+	debug: false, // set to true to debug finding partial/helper issues
 	extensions: ['.html'],
 	helperDirs: [path.resolve('./node_modules/@financial-times/n-handlebars/src/helpers')]
 };

--- a/lib/transforms/base-js.js
+++ b/lib/transforms/base-js.js
@@ -1,6 +1,12 @@
 const BowerWebpackPlugin = require('bower-webpack-plugin');
 const path = require('path');
 
+const handlebarsConfig = {
+	debug: true,
+	extensions: ['.html'],
+	helperDirs: [path.resolve('./node_modules/@financial-times/n-handlebars/src/helpers')]
+};
+
 module.exports = function (options, output) {
 	if (!options.language || options.language === 'js') {
 		output.module.loaders = output.module.loaders.concat([
@@ -12,7 +18,7 @@ module.exports = function (options, output) {
 			},
 			{
 				test: /\.html$/,
-				loader: 'handlebars'
+				loader: 'handlebars?' + JSON.stringify(handlebarsConfig)
 			}
 		])
 		output.plugins.push(

--- a/lib/transforms/base-js.js
+++ b/lib/transforms/base-js.js
@@ -4,7 +4,7 @@ const path = require('path');
 const handlebarsConfig = {
 	debug: false, // set to true to debug finding partial/helper issues
 	extensions: ['.html'],
-	helperDirs: [path.resolve('./node_modules/@financial-times/n-handlebars/src/helpers')]
+	helperDirs: [path.resolve('./node_modules/@financial-times/n-handlebars/src/helpers'), path.resolve('./server/helpers')]
 };
 
 module.exports = function (options, output) {

--- a/lib/transforms/base-js.js
+++ b/lib/transforms/base-js.js
@@ -12,10 +12,6 @@ module.exports = function (options, output) {
 			},
 			{
 				test: /\.html$/,
-				loader: 'raw'
-			},
-			{
-				test: /\.hbs$/,
 				loader: 'handlebars'
 			}
 		])


### PR DESCRIPTION
We're changing `.html` to become Handlebars rather than raw.

This is a breaking change because old `require('raw.html')` returns `<h1>hi</h1>` whereas new `require('handlebars.html')` returns a function that needs to be run for `<h1>hi</h1>`.

Therefore this will be released as a major version.
