### PR TITLE
Add: enable helpers, partials & CSS from node modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,4 @@ exports a function accepting the following options:
 
 
 
-
-
 If `true` is passed in as the second parameter an array of webpack configs will be created, one for each of the growing number of asset variants required by next applications. To exclude certain variants (perhaps because your app takes care of building them itself) a `{exclude: []}` object can be passed in (see lib/variants.js for string values accepted in exclude)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ exports a function accepting the following options:
 - `wrap`: {before, after, options} strings to insert before and after the generated content. options is an optional object containing a regex `match` to select which output files to apply to
 - `env`: prod or dev, to force dev or prod build
 - `outputStats`: a filename to output stats about the build to
-- `handlebarsHelpersDirs`: an optional array of additional locations for app specific handlebars helpers (eg. `handlebarsHelpersDirs: './node_modules/@financial-times/n-teaser/src/handlebars-helpers']`)
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ exports a function accepting the following options:
 - `wrap`: {before, after, options} strings to insert before and after the generated content. options is an optional object containing a regex `match` to select which output files to apply to
 - `env`: prod or dev, to force dev or prod build
 - `outputStats`: a filename to output stats about the build to
+- `handlebarsHelpersDirs`: an optional array of additional locations for app specific handlebars helpers (eg. `handlebarsHelpersDirs: './node_modules/@financial-times/n-teaser/src/handlebars-helpers']`)
 
 
 
-If `true` is passed in as the second parameter ana rray of webpack configs will be created, one for each of the growing number of asset variants required by next applications. To exclude certain variants (perhaps becaus eyour app takes care of building them itself) a `{exclude: []}` object can be passed in (see lib/variants.js for string values accepted in exclude)
+
+If `true` is passed in as the second parameter an array of webpack configs will be created, one for each of the growing number of asset variants required by next applications. To exclude certain variants (perhaps because your app takes care of building them itself) a `{exclude: []}` object can be passed in (see lib/variants.js for string values accepted in exclude)

--- a/lib/transforms/base-js.js
+++ b/lib/transforms/base-js.js
@@ -1,19 +1,23 @@
 const BowerWebpackPlugin = require('bower-webpack-plugin');
 const path = require('path');
 
-const handlebarsConfig = {
-	debug: false, // set to true to debug finding partial/helper issues
-	extensions: ['.html'],
-	helperDirs: [
+const handlebarsConfig = (extraHelperDirs) => {
+	extraHelperDirs = extraHelperDirs.map(dir => path.resolve(dir));
+	return {
+		debug: false, // set to true to debug finding partial/helper issues
+		extensions: ['.html'],
+		helperDirs: [
 			path.resolve('./node_modules/@financial-times/n-handlebars/src/helpers'),
 			path.resolve('./server/helpers'),
 			path.resolve('./node_modules/@financial-times/n-image/dist/handlebars-helpers'),
 			path.resolve('./bower_components/n-concept/handlebars-helpers')
-	],
-	partialDirs: [path.resolve('./bower_components')]
+		].concat(extraHelperDirs)),
+		partialDirs: [path.resolve('./bower_components')]
+	};
 };
 
 module.exports = function (options, output) {
+	const extraHelperDirs = options.handlebarsHelpersDirs || [];
 	if (!options.language || options.language === 'js') {
 		output.module.loaders = output.module.loaders.concat([
 			// don't use requireText plugin (use the 'raw' plugin)
@@ -24,11 +28,11 @@ module.exports = function (options, output) {
 			},
 			{
 				test: /\.html$/,
-				loader: 'handlebars?' + JSON.stringify(handlebarsConfig)
+				loader: 'handlebars?' + JSON.stringify(handlebarsConfig(extraHelperDirs))
 			}
-		])
+		]);
 		output.plugins.push(
 			new BowerWebpackPlugin({ includes: /\.js$/, modulesDirectories: path.resolve('./bower_components') })
-		)
+		);
 	}
 }

--- a/lib/transforms/base-js.js
+++ b/lib/transforms/base-js.js
@@ -11,7 +11,7 @@ const handlebarsConfig = (extraHelperDirs) => {
 			path.resolve('./server/helpers'),
 			path.resolve('./node_modules/@financial-times/n-image/dist/handlebars-helpers'),
 			path.resolve('./bower_components/n-concept/handlebars-helpers')
-		].concat(extraHelperDirs)),
+		].concat(extraHelperDirs),
 		partialDirs: [path.resolve('./bower_components')]
 	};
 };

--- a/lib/transforms/base-js.js
+++ b/lib/transforms/base-js.js
@@ -15,7 +15,7 @@ const handlebarsConfig = () => {
 		].concat(extraHelperDirs),
 		partialDirs: [
 			path.resolve('./bower_components'),
-			path.resolve('./node_modules')
+			path.resolve('./node_modules/@financial-times')
 		]
 	};
 };

--- a/lib/transforms/base-js.js
+++ b/lib/transforms/base-js.js
@@ -21,7 +21,6 @@ const handlebarsConfig = () => {
 };
 
 module.exports = function (options, output) {
-	const extraHelperDirs = options.handlebarsHelpersDirs || [];
 	if (!options.language || options.language === 'js') {
 		output.module.loaders = output.module.loaders.concat([
 			// don't use requireText plugin (use the 'raw' plugin)

--- a/lib/transforms/base-js.js
+++ b/lib/transforms/base-js.js
@@ -3,7 +3,7 @@ const path = require('path');
 const glob = require('glob');
 
 const handlebarsConfig = () => {
-	extraHelperDirs = glob.sync('**/node_modules/@financial-times/**/handlebars-helpers')
+	const extraHelperDirs = glob.sync('**/node_modules/@financial-times/**/handlebars-helpers')
 		.map(dir => path.resolve(dir));
 	return {
 		debug: false, // set to true to debug finding partial/helper issues

--- a/lib/transforms/base-js.js
+++ b/lib/transforms/base-js.js
@@ -1,18 +1,22 @@
 const BowerWebpackPlugin = require('bower-webpack-plugin');
 const path = require('path');
+const glob = require('glob');
 
-const handlebarsConfig = (extraHelperDirs) => {
-	extraHelperDirs = extraHelperDirs.map(dir => path.resolve(dir));
+const handlebarsConfig = () => {
+	extraHelperDirs = glob.sync('**/node_modules/@financial-times/**/handlebars-helpers')
+		.map(dir => path.resolve(dir));
 	return {
 		debug: false, // set to true to debug finding partial/helper issues
 		extensions: ['.html'],
 		helperDirs: [
 			path.resolve('./node_modules/@financial-times/n-handlebars/src/helpers'),
 			path.resolve('./server/helpers'),
-			path.resolve('./node_modules/@financial-times/n-image/dist/handlebars-helpers'),
 			path.resolve('./bower_components/n-concept/handlebars-helpers')
 		].concat(extraHelperDirs),
-		partialDirs: [path.resolve('./bower_components')]
+		partialDirs: [
+			path.resolve('./bower_components'),
+			path.resolve('./node_modules')
+		]
 	};
 };
 
@@ -28,7 +32,7 @@ module.exports = function (options, output) {
 			},
 			{
 				test: /\.html$/,
-				loader: 'handlebars?' + JSON.stringify(handlebarsConfig(extraHelperDirs))
+				loader: 'handlebars?' + JSON.stringify(handlebarsConfig())
 			}
 		]);
 		output.plugins.push(

--- a/lib/transforms/base-scss.js
+++ b/lib/transforms/base-scss.js
@@ -24,7 +24,10 @@ module.exports = function (options, output) {
 		]);
 		output.sassLoader = {
 			sourcemap: true,
-			includePaths: [ path.resolve('./bower_components') ],
+			includePaths: [
+				path.resolve('./bower_components'),
+				path.resolve('./node_modules')
+			],
 			// NOTE: This line is important for preservation of comments needed by the css-extract-block plugin
 			outputStyle: 'expanded'
 		};

--- a/lib/transforms/base-scss.js
+++ b/lib/transforms/base-scss.js
@@ -26,7 +26,7 @@ module.exports = function (options, output) {
 			sourcemap: true,
 			includePaths: [
 				path.resolve('./bower_components'),
-				path.resolve('./node_modules')
+				path.resolve('./node_modules/@financial-times')
 			],
 			// NOTE: This line is important for preservation of comments needed by the css-extract-block plugin
 			outputStyle: 'expanded'

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "clone": "^1.0.2",
     "extract-css-block-webpack-plugin": "^1.3.0",
     "extract-text-webpack-plugin": "^1.0.1",
+    "glob": "^7.1.1",
     "imports-loader": "^0.6.5",
     "protips": "^1.1.0",
     "webpack": "^1.13.1",


### PR DESCRIPTION
To enable us to use just npm rather than both npm & bower, this fixes webpack to look in all the right places.