### PR TITLE
Updated webpack to ^v2.2.1. 

### DIFF
--- a/lib/addons/wrap.js
+++ b/lib/addons/wrap.js
@@ -1,5 +1,5 @@
 // Slightly modified version of entry-wrap-webpack-plugin https://github.com/shakyShane/entry-wrap-webpack-plugin
-const ConcatSource = require('webpack/lib/ConcatSource');
+const ConcatSource = require('webpack-sources/lib/ConcatSource');
 
 function Wrap (before, after, options) {
 	this.options = options || {};

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
     "bower-webpack-plugin": "^0.1.9",
     "clone": "^1.0.2",
     "extract-css-block-webpack-plugin": "^1.3.0",
-    "extract-text-webpack-plugin": "^1.0.1",
+    "extract-text-webpack-plugin": "2.0.0-rc.1",
     "glob": "^7.1.1",
     "imports-loader": "^0.6.5",
     "node-sass": "^3.8.0",
     "postcss-loader": "^0.11.0",
     "raw-loader": "^0.5.1",
     "sass-loader": "^4.0.0",
-    "webpack": "^1.13.3",
+    "webpack": "^2.2.1",
     "webpack-stats-plugin": "^0.1.1"
   },
   "scripts": {


### PR DESCRIPTION
@wheresrhys: This is a bare minimum version update.

Updated extract-text-webpack-plugin to 20.0-rc.1. (version locked because it's a release candidate). 

Fixed ConcatSource path because it moved in webpack v2. 

Passing tests.