### PR TITLE
attempt to configure css-loader to be similar to prod in dev

### DIFF
--- a/lib/transforms/base-scss.js
+++ b/lib/transforms/base-scss.js
@@ -4,12 +4,6 @@ const path = require('path');
 
 module.exports = function (options, output) {
 	if (!options.language || options.language === 'scss') {
-		const extractOptions = process.argv.indexOf('--dev') === -1
-						? [ 'css?minimize&-autoprefixer&sourceMap', 'postcss', 'sass']
-						: [ 'css?sourceMap', 'postcss', 'sass' ]
-		if (options.cssVariant === 'ie8') {
-			extractOptions.push('ie8SassOptions')
-		}
 		output.module.loaders = output.module.loaders.concat([
 			// set 'this' scope to window
 			{
@@ -19,9 +13,24 @@ module.exports = function (options, output) {
 			},
 			{
 				test: /\.scss$/,
-				loader: ExtractTextPlugin.extract(extractOptions)
-			}
+				loader: ExtractTextPlugin.extract([ 'css', 'postcss', 'sass'])
+			},
+
 		]);
+
+		if (process.argv.indexOf('--dev') === -1) {
+			output.css = {
+		    minimize: true,
+		    autoprefixer: false,
+		    sourceMap: true
+			}
+		} else {
+			output.css = {
+		  	minimize: {core: false, discardComments: false, discardDuplicates: true, discardOverridden: true, mergeRules: true},
+		    autoprefixer: false,
+		    sourceMap: true
+		  }
+		}
 
 		output.sassLoader = {
 			sourcemap: true,


### PR DESCRIPTION
via this https://github.com/webpack-contrib/css-loader#minimize and this http://cssnano.co/optimisations/ it should be possible to pick and choose which optimisations we have in dev, specifically we should dedupe rules, but not minify

It's not working and I can't see what I'm doing wrong 🤔 