### PR TITLE
use raw-loader for txt files

### DIFF
--- a/lib/transforms/base-js.js
+++ b/lib/transforms/base-js.js
@@ -33,6 +33,10 @@ module.exports = function (options, output) {
 			{
 				test: /\.html$/,
 				loader: 'handlebars?' + JSON.stringify(handlebarsConfig())
+			},
+			{
+				test: /\.txt$/,
+				loader: 'raw-loader')
 			}
 		]);
 		output.plugins.push(


### PR DESCRIPTION
Using the raw loader for txt files is what OBT and n-ui doing, this PR aligns n-webpack with the change.